### PR TITLE
Logging values to .CSV with no SD card

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool

--- a/examples/csv_disklogger.py
+++ b/examples/csv_disklogger.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022 @Skicka for Adafruit Industries / Hakcat
+# Logging data to .CSV file on CircuitPython Disk
+# SPDX-License-Identifier: MIT
+
+## If you get a read-only filesystem error, you must add "storage.remount('/', False)" in boot.py to enable writing to disk
+## Make sure you add a way to reverse this in boot.py! Otherwise your CP device won't show up via USB anymore 
+## See example here: https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/data-logger
+
+import os
+import time
+import random
+import storage
+import circuitpython_csv as csv
+
+## Check if .CSV file is already present. If not, we write CSV headers.
+all_files = os.listdir() ## List all files in directory
+if "datelog.csv" not in all_files: 
+    with open("datelog.csv", mode="w", encoding="utf-8") as writablefile:
+        csvwriter = csv.writer(writablefile)
+        csvwriter.writerow(["Year", "Month", "Day", "Hour", "Minute"])
+
+## Now that the file exists (or already did) we create a random date & try to append it to the .CSV file
+with open("datelog.csv", mode="a", encoding="utf-8") as writablefile:
+    RandomDate = [random.randint(1999,2022), random.randint(1,12), random.randint(1,30), random.randint(0,23), random.randint(0,60)]
+    csvwriter = csv.writer(writablefile)
+    csvwriter.writerow(RandomDate)
+
+## Finally, we try to read back the last line in the CSV file to make sure it wrote.
+with open("datelog.csv", "r") as file:
+    data = file.readlines()
+    print(data[-1])

--- a/examples/csv_disklogger.py
+++ b/examples/csv_disklogger.py
@@ -2,30 +2,32 @@
 # Logging data to .CSV file on CircuitPython Disk
 # SPDX-License-Identifier: MIT
 
-## If you get a read-only filesystem error, you must add "storage.remount('/', False)" in boot.py to enable writing to disk
-## Make sure you add a way to reverse this in boot.py! Otherwise your CP device won't show up via USB anymore 
-## See example here: https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/data-logger
+# If you get a read-only filesystem error, add "storage.remount('/', False)" in boot.py
+# Make sure you add a way to reverse this in boot.py or your CP device won't show up via USB
+# See example below: 
+# https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/data-logger
 
 import os
-import time
 import random
-import storage
 import circuitpython_csv as csv
 
-## Check if .CSV file is already present. If not, we write CSV headers.
+# Check if .CSV file is already present. If not, we write CSV headers.
 all_files = os.listdir() ## List all files in directory
 if "datelog.csv" not in all_files: 
     with open("datelog.csv", mode="w", encoding="utf-8") as writablefile:
         csvwriter = csv.writer(writablefile)
         csvwriter.writerow(["Year", "Month", "Day", "Hour", "Minute"])
 
-## Now that the file exists (or already did) we create a random date & try to append it to the .CSV file
-with open("datelog.csv", mode="a", encoding="utf-8") as writablefile:
-    RandomDate = [random.randint(1999,2022), random.randint(1,12), random.randint(1,30), random.randint(0,23), random.randint(0,60)]
-    csvwriter = csv.writer(writablefile)
-    csvwriter.writerow(RandomDate)
+# Now that the file exists (or already did) we make a random date 
+year = random.randint(1999,2022); month = random.randint(1,12)
+day = random.randint(1,30); hour = random.randint(0,23); minute = random.randint(0,60)
 
-## Finally, we try to read back the last line in the CSV file to make sure it wrote.
-with open("datelog.csv", "r") as file:
+# We append this to the .CSV file
+with open("datelog.csv", mode="a", encoding="utf-8") as writablefile:
+    csvwriter = csv.writer(writablefile)
+    csvwriter.writerow([year, month, day, hour, minute])
+
+# Finally, we try to read back the last line in the CSV file to make sure it wrote.
+with open("datelog.csv", "r", encoding="utf-8") as file:
     data = file.readlines()
     print(data[-1])

--- a/examples/csv_disklogger.py
+++ b/examples/csv_disklogger.py
@@ -4,7 +4,7 @@
 
 # If you get a read-only filesystem error, add "storage.remount('/', False)" in boot.py
 # Make sure you add a way to reverse this in boot.py or your CP device won't show up via USB
-# See example below: 
+# See example below:
 # https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/data-logger
 
 import os
@@ -12,15 +12,18 @@ import random
 import circuitpython_csv as csv
 
 # Check if .CSV file is already present. If not, we write CSV headers.
-all_files = os.listdir() ## List all files in directory
-if "datelog.csv" not in all_files: 
+all_files = os.listdir()  ## List all files in directory
+if "datelog.csv" not in all_files:
     with open("datelog.csv", mode="w", encoding="utf-8") as writablefile:
         csvwriter = csv.writer(writablefile)
         csvwriter.writerow(["Year", "Month", "Day", "Hour", "Minute"])
 
-# Now that the file exists (or already did) we make a random date 
-year = random.randint(1999,2022); month = random.randint(1,12)
-day = random.randint(1,30); hour = random.randint(0,23); minute = random.randint(0,60)
+# Now that the file exists (or already did) we make a random date
+year = random.randint(1999, 2022)
+month = random.randint(1, 12)
+day = random.randint(1, 30)
+hour = random.randint(0, 23)
+minute = random.randint(0, 60)
 
 # We append this to the .CSV file
 with open("datelog.csv", mode="a", encoding="utf-8") as writablefile:


### PR DESCRIPTION
Example for logging any value to a .CSV file on CircuitPython disk without the need for an SD card, shows append vs write (missing from other examples). Previous examples will always overwrite the whole file (including headers), this shows how to create headers & append to the file.